### PR TITLE
restored distributed processing but made PSy system load from file in…

### DIFF
--- a/src/definitions.jl
+++ b/src/definitions.jl
@@ -29,6 +29,18 @@ const DEFAULT_THERMAL_MTTR_HOURS = 24
 const SIM_START_DATE = Dates.DateTime("2018-01-01T00:00:00")
 const SIM_END_DATE = Dates.DateTime("2019-01-01T00:00:00")
 
+# Maps PSY.Area name to the zone number used in "zone_<n>" identifiers
+const ZONE_NUMBER_MAP = Dict(
+    "FarWest" => 1,
+    "North" => 2,
+    "West" => 3,
+    "Southern" => 4,
+    "NorthCentral" => 5,
+    "SouthCentral" => 6,
+    "Coast" => 7,
+    "East" => 8,
+)
+
 # File pointers
 const TIMESERIES_DATA_DIR = "/projects/gmlcmarkets/Phase2_EMIS_Analysis/NTP_TimeSeries_Data"
 const POINTER_FILE = Dict(

--- a/src/derating_factor_updates/derating_factor_calculator.jl
+++ b/src/derating_factor_updates/derating_factor_calculator.jl
@@ -502,6 +502,8 @@ function calculate_derating_factors(
         availability_df_rt,
     )
 
+    @info "Created base system for derating factor calculation"
+
     # create "Base" PRAS system to be used for calculation of ELCC or EFC.
     base_pras_system = make_pras_system_spi(
         adjusted_base_system,
@@ -513,6 +515,8 @@ function calculate_derating_factors(
 
     # Compute regional load shares once; reused in all PRAS assess calls below.
     regional_load_shares = collect(get_regional_load_shares(base_pras_system))
+
+    @info "Calculating derating factors for new projects"
 
     if marginal_cc
         for zone in zones
@@ -563,6 +567,9 @@ function calculate_derating_factors(
         end
     end
 
+    @info "Finished calculating derating factors for new projects"
+    @info "Calculating derating factors for existing projects"
+
     # For average ELCC/EFC, existing units are removed. The new system with reduced units now becomes the base PRAS system.
     # No deepcopy needed here: SPI.generate_pras_system only reads the PSY system to build a
     # PRAS struct and does not mutate it. The resulting augmented_pras_system is a fresh object.
@@ -603,6 +610,8 @@ function calculate_derating_factors(
         end
     end
 
+    @info "Finished calculating derating factors for existing projects"
+
     all_battery_existing = filter(p -> typeof(p) == BatteryEMIS{Existing}, active_projects)
     all_battery_options = filter(p -> typeof(p) == BatteryEMIS{Option}, active_projects)
 
@@ -634,6 +643,8 @@ function calculate_derating_factors(
         end
     end
 
+    @info "Starting calculation of derating factors for existing storage durations"
+
     for (stor_duration, battery_existing) in existing_storage_duration_dict
         total_capacity = sum(get_maxcap.(battery_existing))
         pruned_base_pras_system =
@@ -653,10 +664,13 @@ function calculate_derating_factors(
         cc_final = (cc_lower + cc_upper) / (2 * total_capacity)
         derating_factors[!, "existing_STOR_$(stor_duration)"] .= cc_final
     end
+    @info "Finished calculation of derating factors for existing storage durations"
 
     # augmented_pras_system is no longer needed after the existing storage loop above.
     # Release it before the battery marginal CC block to reduce peak memory.
     augmented_pras_system = nothing
+
+    @info "Starting calculation of derating factors for new storage durations"
 
     if marginal_cc
         new_project_names = []
@@ -710,6 +724,8 @@ function calculate_derating_factors(
             end
         end
     end
+
+    @info "Finished calculation of derating factors for new storage durations"
 
     # Overwrite file with new derating factors.
     write_data(

--- a/src/investment_simulation.jl
+++ b/src/investment_simulation.jl
@@ -461,33 +461,19 @@ function run_agent_simulation(
         end
 
         @info "Updating derating data for all scenarios in the simulation based on updated resource adequacy and market conditions"
-        # Parallelize the processing of scenarios using Distributed.pmap
-        # NOTE: pmap can crash here because each worker receives serialized PSY.System
-        # objects with process-local SQLite handles inside sys_PRAS.
-        # simulations, iteration_years,
-        # methodologies, ra_metric_list, marginal_cc_switches, timeseries_data_dir_list =
-        #     repeat_arguments(num_scenarios,
-        #         simulation, iteration_year,
-        #         get_accreditation_methodology(case), get_accreditation_metric(case),
-        #         get_marginal_cc_switch(case), timeseries_data_dir)
-        # @timeit EMIS_TIMER "update_derating" Distributed.pmap(parallelize_update_derating_data,
-        #     zip(scenario_names, simulations, iteration_years,
-        #         methodologies, ra_metric_list, marginal_cc_switches,
-        #         timeseries_data_dir_list))
-
-        # Run sequentially to avoid Distributed serialization of PSY.System
-        # objects that contain process-local SQLite handles.
-        @timeit EMIS_TIMER "update_derating" for scenario in scenario_names
-            update_simulation_derating_data!(
-                simulation,
-                scenario,
-                iteration_year,
-                timeseries_data_dir;
-                methodology = get_accreditation_methodology(case),
-                ra_metric = get_accreditation_metric(case),
-                marginal_cc = get_marginal_cc_switch(case),
-            )
-        end
+        # sys_PRAS is reloaded from file on each worker; see parallelize_update_derating_data.
+        pras_sys_paths = [_pras_sys_path(case, s) for s in scenario_names]
+        simulations, iteration_years,
+        methodologies, ra_metric_list, marginal_cc_switches, timeseries_data_dir_list =
+            repeat_arguments(length(scenario_names),
+                simulation, iteration_year,
+                get_accreditation_methodology(case), get_accreditation_metric(case),
+                get_marginal_cc_switch(case), timeseries_data_dir)
+        @timeit EMIS_TIMER "update_derating" Distributed.pmap(
+            parallelize_update_derating_data,
+            zip(scenario_names, simulations, iteration_years,
+                methodologies, ra_metric_list, marginal_cc_switches,
+                timeseries_data_dir_list, pras_sys_paths))
 
         for scenario in scenario_names
             derating_factors = read_data(

--- a/src/resource_adequacy/ra_utils.jl
+++ b/src/resource_adequacy/ra_utils.jl
@@ -178,6 +178,23 @@ function add_capacity_market_device_forecast!(sys_PRAS::PSY.System,
     return
 end
 
+function resolve_unique_component_name(existing_names, requested_name::String)
+    name_set = Set(string.(existing_names))
+    candidate = requested_name
+    if !(candidate in name_set)
+        return candidate
+    end
+
+    suffix = 1
+    while true
+        candidate = "$(requested_name)_$(suffix)"
+        if !(candidate in name_set)
+            return candidate
+        end
+        suffix += 1
+    end
+end
+
 function add_capacity_market_project!(capacity_market_system::PSY.System,
     project::Project,
     simulation_dir::String,
@@ -189,6 +206,15 @@ function add_capacity_market_project!(capacity_market_system::PSY.System,
     availability_df_rt::DataFrame)
 
     # @info "Adding project $(get_name(project)) to capacity market system - scenario $(scenario) for year $(target_year)"
+
+    # Must check against ALL stored components (including unavailable ones), since PSY
+    # enforces name uniqueness on the full component store, not just available techs.
+    current_names = get_all_tech_names(capacity_market_system)
+    unique_name = resolve_unique_component_name(current_names, get_name(project))
+    if unique_name != get_name(project)
+        @warn "Duplicate component name detected for project $(get_name(project)); renaming to $(unique_name) before adding to capacity market system."
+        set_name!(project, unique_name)
+    end
 
     PSY_project = create_PSY_generator(project, capacity_market_system)
     PSY.add_component!(capacity_market_system, PSY_project)
@@ -270,7 +296,7 @@ function create_capacity_mkt_system(initial_system::PSY.System,
         if end_life_year >= capacity_market_year &&
            construction_year <= capacity_market_year
             push!(capacity_market_projects, project)
-            if !(get_name(project) in PSY.get_name.(get_all_techs(capacity_market_system)))
+            if !(get_name(project) in get_all_tech_names(capacity_market_system))
                 add_capacity_market_project!(capacity_market_system, project,
                     simulation_dir, scenario,
                     capacity_market_year, rt_resolution, simulation_years,
@@ -573,7 +599,7 @@ function create_base_system(initial_system::PSY.System,
                         @info "  Area $(area_name) LOLE: $(area_lole[area_name]) hrs/yr"
                     end
                     # Place incremental CTs in the area with the highest LOLE — it is the binding constraint
-                    target_area_name = argmax(area_lole)
+                    target_area_name = argmax(last, area_lole).first
                     target_bus =
                         first(get_buses_in_area(capacity_market_system, target_area_name))
                     target_bus_id = string(PSY.get_number(target_bus))

--- a/src/resource_adequacy/ra_utils.jl
+++ b/src/resource_adequacy/ra_utils.jl
@@ -296,12 +296,14 @@ function create_capacity_mkt_system(initial_system::PSY.System,
         if end_life_year >= capacity_market_year &&
            construction_year <= capacity_market_year
             push!(capacity_market_projects, project)
-            if !(get_name(project) in get_all_tech_names(capacity_market_system))
-                add_capacity_market_project!(capacity_market_system, project,
-                    simulation_dir, scenario,
-                    capacity_market_year, rt_resolution, simulation_years,
-                    timeseries_data_dir, availability_df_rt)
+            if get_name(project) in get_all_tech_names(capacity_market_system)
+                @warn "Skipping project $(get_name(project)) because it is already present in the capacity market system."
+                continue
             end
+            add_capacity_market_project!(capacity_market_system, project,
+                simulation_dir, scenario,
+                capacity_market_year, rt_resolution, simulation_years,
+                timeseries_data_dir, availability_df_rt)
         end
     end
 

--- a/src/resource_adequacy/ra_utils.jl
+++ b/src/resource_adequacy/ra_utils.jl
@@ -221,6 +221,28 @@ function add_capacity_market_project!(capacity_market_system::PSY.System,
     return
 end
 
+"""
+Reassigns an EMIS thermal project's bus and zone (ThermalTech is immutable, so its tech is rebuilt).
+"""
+function set_project_bus!(project::ThermalGenEMIS{<: BuildPhase}, bus::String, zone::String)
+    tech = get_tech(project)
+    project.tech = ThermalTech(
+        tech.type,
+        tech.fuel,
+        tech.active_power_limits,
+        tech.ramp_limits,
+        tech.time_limits,
+        tech.operation_cost,
+        tech.fuel_cost,
+        tech.heat_rate_curve,
+        bus,
+        zone,
+        tech.FOR,
+        tech.MTTR,
+    )
+    return
+end
+
 function create_capacity_mkt_system(initial_system::PSY.System,
     active_projects::Vector{Project},
     capacity_forward_years::Int64,
@@ -364,6 +386,21 @@ function update_delta_irm!(initial_system::PSY.System,
                     first(filter(p -> occursin("new_CT", get_name(p)), active_projects))
 
                 if !(adequacy_conditions_met)
+                    ct_bus_id = get_bus(get_tech(ct_project_template))
+                    ct_bus_match = filter(
+                        b ->
+                            string(PSY.get_number(b)) == ct_bus_id ||
+                            PSY.get_name(b) == ct_bus_id,
+                        collect(PSY.get_components(PSY.Bus, capacity_market_system)),
+                    )
+                    if !isempty(ct_bus_match)
+                        @info "CT template bus=$(ct_bus_id) → area=$(PSY.get_name(PSY.get_area(first(ct_bus_match))))"
+                    end
+                    for area in PSY.get_components(PSY.Area, capacity_market_system)
+                        area_lole =
+                            val(PRAS.LOLE(shortfall, PSY.get_name(area))) / simulation_years
+                        @info "  Area $(PSY.get_name(area)) LOLE: $(area_lole) hrs/yr"
+                    end
                     while !(adequacy_conditions_met)
                         @info "RA metrics: $(ra_metrics)"
                         @info "Updating delta IRM for scenario: $(scenario) - Year: $(iteration_year)"
@@ -516,7 +553,32 @@ function create_base_system(initial_system::PSY.System,
                 first(filter(p -> occursin("new_CT", get_name(p)), active_projects))
 
             if !(adequacy_conditions_met)
+                ct_bus_id = get_bus(get_tech(ct_project_template))
+                ct_bus_match = filter(
+                    b ->
+                        string(PSY.get_number(b)) == ct_bus_id ||
+                        PSY.get_name(b) == ct_bus_id,
+                    collect(PSY.get_components(PSY.Bus, capacity_market_system)),
+                )
+                if !isempty(ct_bus_match)
+                    @info "CT template bus=$(ct_bus_id) → area=$(PSY.get_name(PSY.get_area(first(ct_bus_match))))"
+                end
+
                 while !(adequacy_conditions_met)
+                    area_lole = Dict{String, Float64}()
+                    for area in PSY.get_components(PSY.Area, capacity_market_system)
+                        area_name = PSY.get_name(area)
+                        area_lole[area_name] =
+                            val(PRAS.LOLE(shortfall, area_name)) / simulation_years
+                        @info "  Area $(area_name) LOLE: $(area_lole[area_name]) hrs/yr"
+                    end
+                    # Place incremental CTs in the area with the highest LOLE — it is the binding constraint
+                    target_area_name = argmax(area_lole)
+                    target_bus =
+                        first(get_buses_in_area(capacity_market_system, target_area_name))
+                    target_bus_id = string(PSY.get_number(target_bus))
+                    target_zone = get_zone_for_area(target_area_name)
+                    @info "Targeting area $(target_area_name) (bus $(PSY.get_name(target_bus))) for incremental CTs"
                     scalar = 2
                     ratio = 0
                     for metric in keys(ra_targets)
@@ -528,6 +590,7 @@ function create_base_system(initial_system::PSY.System,
                     for i in 1:ceil(ratio)
                         incremental_project = deepcopy(ct_project_template)
                         set_name!(incremental_project, "addition_CT_project_$(count)")
+                        set_project_bus!(incremental_project, target_bus_id, target_zone)
                         total_added_capacity += get_maxcap(incremental_project)
                         add_capacity_market_project!(
                             capacity_market_system,

--- a/src/resource_adequacy/ra_utils.jl
+++ b/src/resource_adequacy/ra_utils.jl
@@ -56,7 +56,8 @@ function calculate_RA_metrics(sys::PSY.System,
     iteration_year::Int64;
     samples::Int64 = PRAS_N_SAMPLES,
     seed::Int64 = 42,
-    simulation_years::Int64 = 15)
+    simulation_years::Int64 = 15,
+    overwrite_outage_with_ext::Bool = false)
     system_period_of_interest = range(1; length = DEFAULT_HOURS_PER_YEAR * simulation_years);
     # correlated_outage_csv_location = joinpath(outage_dir, "ThermalFOR_scenario_1_new.csv")
 
@@ -65,7 +66,9 @@ function calculate_RA_metrics(sys::PSY.System,
     # Build PRAS.SystemModel on the main process (needs PSY.System's live SQLite connection).
     # PRAS.SystemModel is plain arrays — safe to serialize and send to a remote worker.
     # generate_pras_system is in SiennaPRASInterface (SPI), not in PRASCore (PRAS).
-    @timeit EMIS_TIMER "attach_outage_data" attach_outage_data_from_ext!(sys)
+    if overwrite_outage_with_ext
+        @timeit EMIS_TIMER "attach_outage_data" attach_outage_data_from_ext!(sys)
+    end
     pras_system =
         @timeit EMIS_TIMER "generate_pras_system" SPI.generate_pras_system(sys, PSY.Area)
 

--- a/src/struct_creators/simulation_structs/agent_simulation_creator.jl
+++ b/src/struct_creators/simulation_structs/agent_simulation_creator.jl
@@ -440,47 +440,27 @@ function gather_data(case::CaseDefinition; results_dir::Union{String, Nothing} =
         end
     end
 
-    # Parallelize the processing of scenarios using Distributed.pmap
-    # NOTE: pmap can crash here because each worker receives serialized PSY.System
-    # objects with process-local SQLite handles inside sys_PRAS.
-    # simulations,
-    # iteration_years,
-    # methodologies,
-    # ra_metric_list,
-    # marginal_cc_switches = repeat_arguments(
-    #     num_scenarios,
-    #     simulation_data,
-    #     iteration_year,
-    #     accreditation_methodology,
-    #     accreditation_metric,
-    #     marginal_cc_switch,
-    # )
-    # @timeit EMIS_TIMER "setup/update_derating" Distributed.pmap(
-    #     parallelize_update_derating_data,
-    #     zip(
-    #         scenarios,
-    #         simulations,
-    #         iteration_years,
-    #         methodologies,
-    #         ra_metric_list,
-    #         marginal_cc_switches,
-    #         timeseries_data_dir_list,
-    #     ),
-    # )
-
-    # Run sequentially to avoid Distributed serialization of PSY.System
-    # objects that contain process-local SQLite handles.
-    @timeit EMIS_TIMER "setup/update_derating" for scenario in scenarios
-        update_simulation_derating_data!(
-            simulation_data,
-            scenario,
-            iteration_year,
-            timeseries_data_dir;
-            methodology = accreditation_methodology,
-            ra_metric = accreditation_metric,
-            marginal_cc = marginal_cc_switch,
-        )
-    end
+    # sys_PRAS is reloaded from file on each worker; see parallelize_update_derating_data.
+    pras_sys_paths = [_pras_sys_path(get_case(simulation_data), s) for s in scenarios]
+    simulations, iteration_years,
+    methodologies, ra_metric_list, marginal_cc_switches, timeseries_data_dir_list =
+        repeat_arguments(length(scenarios),
+            simulation_data, iteration_year,
+            accreditation_methodology, accreditation_metric,
+            marginal_cc_switch, timeseries_data_dir)
+    @timeit EMIS_TIMER "setup/update_derating" Distributed.pmap(
+        parallelize_update_derating_data,
+        zip(
+            scenarios,
+            simulations,
+            iteration_years,
+            methodologies,
+            ra_metric_list,
+            marginal_cc_switches,
+            timeseries_data_dir_list,
+            pras_sys_paths,
+        ),
+    )
 
     active_projects = get_activeprojects(simulation_data)
 

--- a/src/utils/parallel_utils.jl
+++ b/src/utils/parallel_utils.jl
@@ -213,6 +213,16 @@ function repeat_arguments(num_scenarios::Int, args...)
 end
 
 """
+Returns the path to the PRAS PSY.System JSON file for a given scenario.
+"""
+function _pras_sys_path(case::CaseDefinition, scenario::String)
+    return joinpath(
+        get_sys_dir(case), "constructed_systems", scenario, "sim_year_1",
+        "PRAS_sys_EMIS_$(get_ed_horizon(case))hor_$(get_ed_interval(case))int_$(get_md_horizon(case))mdhor_$(get_md_interval(case))mdint.json",
+    )
+end
+
+"""
 This function runs the update_simulation_derating_data! function in parallel for different scenarios.
 """
 function parallelize_update_derating_data(args)
@@ -222,7 +232,15 @@ function parallelize_update_derating_data(args)
     methodology,
     ra_metric,
     marginal_cc,
-    timeseries_data_dir = args
+    timeseries_data_dir,
+    pras_sys_path = args
+    # PSY.System holds a process-local SQLite handle that becomes a stale pointer
+    # after cross-process serialization. Reload from file to get a valid handle.
+    simulation.system_PRAS[scenario] = PSY.System(
+        pras_sys_path;
+        time_series_directory = get_scratch_dir(get_case(simulation)),
+        runchecks = false,
+    )
     update_simulation_derating_data!(
         simulation,
         scenario,

--- a/src/utils/parallel_utils.jl
+++ b/src/utils/parallel_utils.jl
@@ -1,7 +1,10 @@
 """
 This function creates parallel workers for making price predictions.
+
+Keyword `n_threads` configures each spawned worker process with Julia threads.
+The default keeps the historical behavior of a single-threaded worker pool.
 """
-function create_parallel_workers(case::CaseDefinition, hpc::Bool)
+function create_parallel_workers(case::CaseDefinition, hpc::Bool; n_threads::Int = 1)
     data_dir = get_data_dir(case)
     dir_name = joinpath(data_dir, "investors")
     investor_names = readdir(dir_name)
@@ -50,10 +53,14 @@ function create_parallel_workers(case::CaseDefinition, hpc::Bool)
             nodes = split(ENV["SLURM_NODELIST"], ",")
             num_procs = min(Int(ceil(num_workers_required / length(nodes))), 4)
             node_pairs = [(n, num_procs) for n in nodes]
-            Distributed.addprocs(node_pairs)
+            Distributed.addprocs(node_pairs; exeflags = "--threads=$(n_threads)")
         else
             num_workers = min(Int(num_workers_required), 4)
-            Distributed.addprocs(num_workers; lazy = false)
+            Distributed.addprocs(
+                num_workers;
+                lazy = false,
+                exeflags = "--threads=$(n_threads)",
+            )
         end
     end
 

--- a/src/utils/siip_psy_utils.jl
+++ b/src/utils/siip_psy_utils.jl
@@ -14,6 +14,18 @@ function get_all_techs(sys::PSY.System)
 end
 
 """
+Returns names of all generation and storage components stored in the PSY System,
+including unavailable ones. Component name uniqueness in PSY is enforced against the
+full component store regardless of `available`, so this (not `get_all_techs`) is the
+correct source of truth for duplicate-name checks before `PSY.add_component!`.
+"""
+function get_all_tech_names(sys::PSY.System)
+    sys_gens = PSY.get_components(PSY.Generator, sys)
+    sys_storage = PSY.get_components(PSY.Storage, sys)
+    return PSY.get_name.(union(sys_gens, sys_storage))
+end
+
+"""
 This function does nothing if the PSY System is not defined.
 """
 function get_system_services(sys::Nothing)

--- a/src/utils/siip_psy_utils.jl
+++ b/src/utils/siip_psy_utils.jl
@@ -579,23 +579,20 @@ function find_zonal_bus(zone::String, sys::PSY.System)
 end
 
 function find_zonal_area(zone::String, sys::PSY.System)
-    zone_number_map = Dict(
-        "FarWest" => 1,
-        "North" => 2,
-        "West" => 3,
-        "Southern" => 4,
-        "NorthCentral" => 5,
-        "SouthCentral" => 6,
-        "Coast" => 7,
-        "East" => 8,
-    )
     for area in PSY.get_components(PSY.Area, sys)
         name = PSY.get_name(area)
-        if zone == "zone_$(zone_number_map[name])"
+        if zone == "zone_$(ZONE_NUMBER_MAP[name])"
             return area
         end
     end
     return nothing
+end
+
+"""
+Returns the "zone_<n>" identifier for a given PSY.Area name, using `ZONE_NUMBER_MAP`.
+"""
+function get_zone_for_area(area_name::String)
+    return "zone_$(ZONE_NUMBER_MAP[area_name])"
 end
 
 """
@@ -678,6 +675,19 @@ function add_nominal_outage_to_component!(sys::PSY.System, component::PSY.Compon
     )
     PSY.add_supplemental_attribute!(sys, component, attr)
     return
+end
+
+"""
+Return all `PSY.Bus` components in `sys` that belong to the area named `area_name`.
+"""
+function get_buses_in_area(sys::PSY.System, area_name::String)
+    return collect(
+        PSY.get_components(
+            b -> PSY.get_name(PSY.get_area(b)) == area_name,
+            PSY.Bus,
+            sys,
+        ),
+    )
 end
 
 function add_psy_inertia!(simulation_dir::String,

--- a/test/test_update_derating_factor.jl
+++ b/test/test_update_derating_factor.jl
@@ -12,6 +12,14 @@ using EMISAgentSimulation
 include(joinpath(@__DIR__, "helpers.jl"))
 
 @testset "update_derating_factor!" begin
+    @testset "duplicate component names" begin
+        @test EMISAgentSimulation.resolve_unique_component_name(
+            ["gen-543", "gen-543_1"],
+            "gen-543",
+        ) == "gen-543_2"
+        @test EMISAgentSimulation.resolve_unique_component_name(["gen-543"], "new_name") ==
+              "new_name"
+    end
 
     # ── ThermalGenEMIS / HydroGenEMIS ────────────────────────────────────────
 


### PR DESCRIPTION
Was getting `UNHANDLED TASK ERROR: EOFError: read end of file` when trying to call `Distributed.pmap` to `parallelize_update_derating_data`. The stack trace revealed that the error was caused deep inside `InfrastructureSystems.jl`  calling `sqlite3_backup_init`

```
From worker 2:	[3735254] signal 11 (1): Segmentation fault
From worker 2:	sqlite3_backup_init at /kfs2/projects/gmlcmarkets/GS_EMIS_PACKAGES_PGHOSH/.julia/artifacts/b43a567606784a0d3fc06291c67f4ec5243791e6/lib/libsqlite3.so (unknown line)
From worker 2:	#backup#52 at /projects/gmlcmarkets/GS_EMIS_PACKAGES_PGHOSH/.julia/packages/InfrastructureSystems/euBLZ/src/utils/sqlite.jl:21
```

Likely this is caused by AgentSimulation structs that contain `system_PRAS` PSY systems with timeseries data which holds an in-memory SQLite database. The sqlite database is not safely passed on from the main process to the worker processes after `Distributed.pmap` https://stackoverflow.com/questions/1063438/sqlite3-and-multiple-processes.

So this PR attempts to fix that by having the worker process load the PSY systems from files directory without using the shared in-memory system.