### PR TITLE
Implement PRAS part of derating factor calculator

### DIFF
--- a/src/derating_factor_updates/derating_factor_calculator.jl
+++ b/src/derating_factor_updates/derating_factor_calculator.jl
@@ -528,6 +528,37 @@ function build_augmented_pras_system(
 end
 
 """
+Runs a single PRAS.assess call for one season with the fixed Monte Carlo seed/sample
+count (`PRAS_N_SAMPLES`, `PRAS_MONTE_CARLO_SEED`), and reduces the result to the
+scalar capacity-credit fraction used by `calculate_derating_factors`. This is the
+only piece of the per-season derating calculation dispatched via
+`Distributed.pmap`; the (expensive) full-horizon system builds and
+`subset_pras_system` calls stay on the main process. Since the seed/sample count
+are fixed and identical for every season regardless of execution order, dispatching
+this call across workers (or running it all on the single main process, when no
+extra workers exist) is deterministic and produces byte-identical results to the
+serial version.
+"""
+function pras_assess_cc(
+    season_base_system::PRAS.SystemModel,
+    season_augmented_system::PRAS.SystemModel,
+    accreditation,
+    cap::Float64,
+)
+    cc_result = PRAS.assess(
+        season_base_system,
+        season_augmented_system,
+        accreditation,
+        PRAS.SequentialMonteCarlo(;
+            samples = PRAS_N_SAMPLES,
+            seed = PRAS_MONTE_CARLO_SEED,
+        ),
+    )
+    cc_lower, cc_upper = extrema(cc_result)
+    return (cc_lower + cc_upper) / (2 * cap)
+end
+
+"""
 Calculates raw (unscaled) capacity credit values for existing and new renewable generation
 and storage using PRAS (ELCC or EFC methodology), then writes them to `derating_dict.csv`.
 Per-type scalars are applied later in `update_derating_factor!`.
@@ -559,6 +590,32 @@ function calculate_derating_factors(
 
     simulation_dir = get_data_dir(get_case(simulation))
     simulation_years = get_total_horizon(get_case(simulation))
+
+    # Seasonal setup, mirroring the exact pattern used by calculate_derating_data.
+    seasons_file = get_capacity_seasons_file(simulation_dir)
+    seasonal_capacity_market = get_seasonal_capacity_market(get_case(simulation))
+    season_months = load_season_months(seasons_file)
+    seasonal_mode = !is_annual_only_seasons(season_months, seasonal_capacity_market)
+    if !seasonal_mode
+        # Keep downstream loops uniform by using a single synthetic annual season.
+        season_months = Dict{String, Vector{Int64}}("annual" => collect(1:12))
+    end
+    seasons = collect(keys(season_months))
+
+    # Precompute the hour-columns selected by each season (divide approach). In
+    # annual mode this is always 1:(DEFAULT_HOURS_PER_YEAR*simulation_years), i.e.
+    # every column, so subset_pras_system(sys, season_cols["annual"]) reproduces the
+    # full-horizon system exactly (annual-mode byte-equivalence).
+    season_cols = Dict{String, Vector{Int}}()
+    for season in seasons
+        cols = season_hour_columns(season_months[season], simulation_years)
+        if isempty(cols)
+            @warn "No hours found for season '$season' while calculating PRAS derating factors."
+            continue
+        end
+        season_cols[season] = cols
+    end
+
     outage_dir = get_outage_dir(get_case(simulation))
     rt_resolution = get_rt_resolution(get_case(simulation))
     zones = get_zones(simulation)
@@ -566,7 +623,7 @@ function calculate_derating_factors(
     availability_df_rt =
         get_availability_df(timeseries_data_dir, scenario, simulation_years, "REAL_TIME")
 
-    derating_factors = read_data(
+    derating_template = read_data(
         joinpath(
             simulation_dir,
             "markets_data",
@@ -575,6 +632,8 @@ function calculate_derating_factors(
             "derating_dict.csv",
         ),
     )
+    derating_factors = initialize_derating_output(derating_template, seasons, seasonal_mode)
+    season_row_index = Dict(season => idx for (idx, season) in enumerate(seasons))
 
     active_projects = get_activeprojects(simulation)
     existing = filter(p -> typeof(p) == RenewableGenEMIS{Existing}, active_projects)
@@ -614,8 +673,17 @@ function calculate_derating_factors(
         copy_system = false,
     )
 
-    # Compute regional load shares once; reused in all PRAS assess calls below.
-    regional_load_shares = collect(get_regional_load_shares(base_pras_system))
+    # Subset the full-horizon base system once per season (divide approach). Full
+    # PSY/PRAS system builds are expensive and season-independent, so they are built
+    # once above; only the cheap column-subset + regional-load-share recompute is
+    # repeated per season. See subset_pras_system's docstring for the SoC/outage-seam
+    # caveat inherent to this divide approach.
+    base_pras_season_systems =
+        Dict(season => subset_pras_system(base_pras_system, cols) for (season, cols) in season_cols)
+    regional_load_shares_by_season = Dict(
+        season => collect(get_regional_load_shares(sys)) for
+        (season, sys) in base_pras_season_systems
+    )
 
     if marginal_cc
         for zone in zones
@@ -636,7 +704,8 @@ function calculate_derating_factors(
                         set_name!(p, "$(get_name(p))_$i")
                         push!(new_projects, p)
                     end
-                    augmented_pras_system = build_augmented_pras_system(
+                    # Full-horizon build (expensive) once per zone/type; subset per season below.
+                    augmented_pras_system_full = build_augmented_pras_system(
                         adjusted_base_system,
                         new_projects,
                         simulation_dir,
@@ -648,19 +717,38 @@ function calculate_derating_factors(
                         availability_df_rt,
                     )
 
-                    # Call PRAS accreditation methodology. Adjust sample size, seed, etc. here.
-                    cc_result = PRAS.assess(
-                        base_pras_system,
-                        augmented_pras_system,
-                        methodology{ra_metric}(Int(ceil(max_cap)), regional_load_shares),
-                        PRAS.SequentialMonteCarlo(;
-                            samples = PRAS_N_SAMPLES,
-                            seed = PRAS_MONTE_CARLO_SEED,
-                        ),
+                    # Per-season subset systems + accreditation objects (built once, on
+                    # the main process, as today). Only the pure PRAS.assess reduction
+                    # for each season is dispatched via pmap below; this is deterministic
+                    # because every season uses the SAME fixed seed/samples and its
+                    # inputs are independent of execution order (see pras_assess_cc docs).
+                    valid_seasons = [s for s in seasons if haskey(season_cols, s)]
+                    season_assess_args = Dict(
+                        s => (
+                            base_pras_season_systems[s],
+                            subset_pras_system(augmented_pras_system_full, season_cols[s]),
+                            methodology{ra_metric}(
+                                Int(ceil(max_cap)),
+                                regional_load_shares_by_season[s],
+                            ),
+                            max_cap,
+                        ) for s in valid_seasons
                     )
-                    cc_lower, cc_upper = extrema(cc_result)
-                    cc_final = (cc_lower + cc_upper) / (2 * max_cap)
-                    derating_factors[!, "new_$(type)_$(zone)"] .= cc_final
+                    cc_results = Distributed.pmap(valid_seasons) do s
+                        season_base_system, season_augmented_system, accreditation, cap =
+                            season_assess_args[s]
+                        cc_final = pras_assess_cc(
+                            season_base_system,
+                            season_augmented_system,
+                            accreditation,
+                            cap,
+                        )
+                        s => cc_final
+                    end
+                    for (s, cc_final) in cc_results
+                        derating_factors[season_row_index[s], "new_$(type)_$(zone)"] =
+                            cc_final
+                    end
                 end
             end
         end
@@ -669,12 +757,18 @@ function calculate_derating_factors(
     # For average ELCC/EFC, existing units are removed. The new system with reduced units now becomes the base PRAS system.
     # No deepcopy needed here: SPI.generate_pras_system only reads the PSY system to build a
     # PRAS struct and does not mutate it. The resulting augmented_pras_system is a fresh object.
-    augmented_pras_system = make_pras_system_spi(
+    # Full-horizon build (expensive, season-independent) once; subset per season below and
+    # reuse across both the existing-renewables loop and the existing-storage loop.
+    augmented_pras_system_full = make_pras_system_spi(
         adjusted_base_system,
         PSY.Area,
         nothing;
         copper_plate = false,
         copy_system = false,
+    )
+    augmented_pras_season_systems = Dict(
+        season => subset_pras_system(augmented_pras_system_full, cols) for
+        (season, cols) in season_cols
     )
 
     for zone in zones
@@ -686,22 +780,37 @@ function calculate_derating_factors(
             if !isempty(zone_tech_units)
                 total_capacity = sum(get_maxcap.(zone_tech_units))
                 @assert total_capacity > 0
-                pruned_base_pras_system =
+                # Full-horizon build (expensive) once per zone/type; subset per season below.
+                pruned_base_pras_system_full =
                     build_pruned_pras_system(adjusted_base_system, zone_tech_units)
-                #  Call PRAS accreditation methodology. Adjust sample size, seed, etc. here.
-                cc_result = PRAS.assess(
-                    pruned_base_pras_system,
-                    augmented_pras_system,
-                    PRAS.ELCC{ra_metric}(Int(ceil(total_capacity)), regional_load_shares),
-                    PRAS.SequentialMonteCarlo(;
-                        samples = PRAS_N_SAMPLES,
-                        seed = PRAS_MONTE_CARLO_SEED,
-                    ),
-                )
-                cc_lower, cc_upper = extrema(cc_result)
-                cc_final = (cc_lower + cc_upper) / (2 * total_capacity)
 
-                derating_factors[!, "existing_$(type)_$(zone)"] .= cc_final
+                valid_seasons = [s for s in seasons if haskey(season_cols, s)]
+                season_assess_args = Dict(
+                    s => (
+                        subset_pras_system(pruned_base_pras_system_full, season_cols[s]),
+                        augmented_pras_season_systems[s],
+                        PRAS.ELCC{ra_metric}(
+                            Int(ceil(total_capacity)),
+                            regional_load_shares_by_season[s],
+                        ),
+                        total_capacity,
+                    ) for s in valid_seasons
+                )
+                cc_results = Distributed.pmap(valid_seasons) do s
+                    season_pruned_system, season_augmented_system, accreditation, cap =
+                        season_assess_args[s]
+                    cc_final = pras_assess_cc(
+                        season_pruned_system,
+                        season_augmented_system,
+                        accreditation,
+                        cap,
+                    )
+                    s => cc_final
+                end
+                for (s, cc_final) in cc_results
+                    derating_factors[season_row_index[s], "existing_$(type)_$(zone)"] =
+                        cc_final
+                end
             end
         end
     end
@@ -739,27 +848,43 @@ function calculate_derating_factors(
 
     for (stor_duration, battery_existing) in existing_storage_duration_dict
         total_capacity = sum(get_maxcap.(battery_existing))
-        pruned_base_pras_system =
+        # Full-horizon build (expensive) once per duration; subset per season below.
+        pruned_base_pras_system_full =
             build_pruned_pras_system(adjusted_base_system, battery_existing)
 
-        # Call PRAS accreditation methodology. Adjust sample size, seed, etc. here.
-        cc_result = PRAS.assess(
-            pruned_base_pras_system,
-            augmented_pras_system,
-            PRAS.ELCC{ra_metric}(Int(ceil(total_capacity)), regional_load_shares),
-            PRAS.SequentialMonteCarlo(;
-                samples = PRAS_N_SAMPLES,
-                seed = PRAS_MONTE_CARLO_SEED,
-            ),
+        valid_seasons = [s for s in seasons if haskey(season_cols, s)]
+        season_assess_args = Dict(
+            s => (
+                subset_pras_system(pruned_base_pras_system_full, season_cols[s]),
+                augmented_pras_season_systems[s],
+                PRAS.ELCC{ra_metric}(
+                    Int(ceil(total_capacity)),
+                    regional_load_shares_by_season[s],
+                ),
+                total_capacity,
+            ) for s in valid_seasons
         )
-        cc_lower, cc_upper = extrema(cc_result)
-        cc_final = (cc_lower + cc_upper) / (2 * total_capacity)
-        derating_factors[!, "existing_STOR_$(stor_duration)"] .= cc_final
+        cc_results = Distributed.pmap(valid_seasons) do s
+            season_pruned_system, season_augmented_system, accreditation, cap =
+                season_assess_args[s]
+            cc_final = pras_assess_cc(
+                season_pruned_system,
+                season_augmented_system,
+                accreditation,
+                cap,
+            )
+            s => cc_final
+        end
+        for (s, cc_final) in cc_results
+            derating_factors[season_row_index[s], "existing_STOR_$(stor_duration)"] =
+                cc_final
+        end
     end
 
-    # augmented_pras_system is no longer needed after the existing storage loop above.
-    # Release it before the battery marginal CC block to reduce peak memory.
-    augmented_pras_system = nothing
+    # augmented_pras_system(s) are no longer needed after the existing storage loop above.
+    # Release them before the battery marginal CC block to reduce peak memory.
+    augmented_pras_system_full = nothing
+    augmented_pras_season_systems = nothing
 
     if marginal_cc
         new_project_names = []
@@ -775,7 +900,8 @@ function calculate_derating_factors(
                     push!(new_projects, new_project)
                 end
             end
-            augmented_pras_system = build_augmented_pras_system(
+            # Full-horizon build (expensive) once per duration; subset per season below.
+            augmented_pras_system_full = build_augmented_pras_system(
                 adjusted_base_system,
                 new_projects,
                 simulation_dir,
@@ -787,19 +913,33 @@ function calculate_derating_factors(
                 availability_df_rt,
             )
 
-            # Call PRAS accreditation methodology. Adjust sample size, seed, etc. here.
-            cc_result = PRAS.assess(
-                base_pras_system,
-                augmented_pras_system,
-                methodology{ra_metric}(Int(ceil(max_cap)), regional_load_shares),
-                PRAS.SequentialMonteCarlo(;
-                    samples = PRAS_N_SAMPLES,
-                    seed = PRAS_MONTE_CARLO_SEED,
-                ),
+            valid_seasons = [s for s in seasons if haskey(season_cols, s)]
+            season_assess_args = Dict(
+                s => (
+                    base_pras_season_systems[s],
+                    subset_pras_system(augmented_pras_system_full, season_cols[s]),
+                    methodology{ra_metric}(
+                        Int(ceil(max_cap)),
+                        regional_load_shares_by_season[s],
+                    ),
+                    max_cap,
+                ) for s in valid_seasons
             )
-            cc_lower, cc_upper = extrema(cc_result)
-            cc_final = (cc_lower + cc_upper) / (2 * max_cap)
-            derating_factors[!, "new_STOR_$(stor_duration)"] .= cc_final
+            cc_results = Distributed.pmap(valid_seasons) do s
+                season_base_system, season_augmented_system, accreditation, cap =
+                    season_assess_args[s]
+                cc_final = pras_assess_cc(
+                    season_base_system,
+                    season_augmented_system,
+                    accreditation,
+                    cap,
+                )
+                s => cc_final
+            end
+            for (s, cc_final) in cc_results
+                derating_factors[season_row_index[s], "new_STOR_$(stor_duration)"] =
+                    cc_final
+            end
         end
 
     else

--- a/src/derating_factor_updates/derating_factor_calculator.jl
+++ b/src/derating_factor_updates/derating_factor_calculator.jl
@@ -47,7 +47,11 @@ function initialize_derating_output(
     seasonal_mode::Bool,
 )
     if !seasonal_mode
-        return deepcopy(derating_template)
+        annual_output = deepcopy(derating_template[1:1, :])
+        if "season" in names(annual_output)
+            select!(annual_output, Not("season"))
+        end
+        return annual_output
     end
 
     # Use the template's first row as the baseline for every season, preserving any
@@ -723,29 +727,26 @@ function calculate_derating_factors(
                     # because every season uses the SAME fixed seed/samples and its
                     # inputs are independent of execution order (see pras_assess_cc docs).
                     valid_seasons = [s for s in seasons if haskey(season_cols, s)]
-                    season_assess_args = Dict(
-                        s => (
-                            base_pras_season_systems[s],
-                            subset_pras_system(augmented_pras_system_full, season_cols[s]),
-                            methodology{ra_metric}(
-                                Int(ceil(max_cap)),
-                                regional_load_shares_by_season[s],
-                            ),
-                            max_cap,
+                    season_base_systems =
+                        [base_pras_season_systems[s] for s in valid_seasons]
+                    season_augmented_systems = [
+                        subset_pras_system(augmented_pras_system_full, season_cols[s]) for
+                        s in valid_seasons
+                    ]
+                    accreditations = [
+                        methodology{ra_metric}(
+                            Int(ceil(max_cap)),
+                            regional_load_shares_by_season[s],
                         ) for s in valid_seasons
+                    ]
+                    cc_results = Distributed.pmap(
+                        pras_assess_cc,
+                        season_base_systems,
+                        season_augmented_systems,
+                        accreditations,
+                        fill(max_cap, length(valid_seasons)),
                     )
-                    cc_results = Distributed.pmap(valid_seasons) do s
-                        season_base_system, season_augmented_system, accreditation, cap =
-                            season_assess_args[s]
-                        cc_final = pras_assess_cc(
-                            season_base_system,
-                            season_augmented_system,
-                            accreditation,
-                            cap,
-                        )
-                        s => cc_final
-                    end
-                    for (s, cc_final) in cc_results
+                    for (s, cc_final) in zip(valid_seasons, cc_results)
                         derating_factors[season_row_index[s], "new_$(type)_$(zone)"] =
                             cc_final
                     end
@@ -785,29 +786,26 @@ function calculate_derating_factors(
                     build_pruned_pras_system(adjusted_base_system, zone_tech_units)
 
                 valid_seasons = [s for s in seasons if haskey(season_cols, s)]
-                season_assess_args = Dict(
-                    s => (
-                        subset_pras_system(pruned_base_pras_system_full, season_cols[s]),
-                        augmented_pras_season_systems[s],
-                        PRAS.ELCC{ra_metric}(
-                            Int(ceil(total_capacity)),
-                            regional_load_shares_by_season[s],
-                        ),
-                        total_capacity,
+                season_pruned_systems = [
+                    subset_pras_system(pruned_base_pras_system_full, season_cols[s]) for
+                    s in valid_seasons
+                ]
+                season_augmented_systems =
+                    [augmented_pras_season_systems[s] for s in valid_seasons]
+                accreditations = [
+                    PRAS.ELCC{ra_metric}(
+                        Int(ceil(total_capacity)),
+                        regional_load_shares_by_season[s],
                     ) for s in valid_seasons
+                ]
+                cc_results = Distributed.pmap(
+                    pras_assess_cc,
+                    season_pruned_systems,
+                    season_augmented_systems,
+                    accreditations,
+                    fill(total_capacity, length(valid_seasons)),
                 )
-                cc_results = Distributed.pmap(valid_seasons) do s
-                    season_pruned_system, season_augmented_system, accreditation, cap =
-                        season_assess_args[s]
-                    cc_final = pras_assess_cc(
-                        season_pruned_system,
-                        season_augmented_system,
-                        accreditation,
-                        cap,
-                    )
-                    s => cc_final
-                end
-                for (s, cc_final) in cc_results
+                for (s, cc_final) in zip(valid_seasons, cc_results)
                     derating_factors[season_row_index[s], "existing_$(type)_$(zone)"] =
                         cc_final
                 end
@@ -853,29 +851,26 @@ function calculate_derating_factors(
             build_pruned_pras_system(adjusted_base_system, battery_existing)
 
         valid_seasons = [s for s in seasons if haskey(season_cols, s)]
-        season_assess_args = Dict(
-            s => (
-                subset_pras_system(pruned_base_pras_system_full, season_cols[s]),
-                augmented_pras_season_systems[s],
-                PRAS.ELCC{ra_metric}(
-                    Int(ceil(total_capacity)),
-                    regional_load_shares_by_season[s],
-                ),
-                total_capacity,
+        season_pruned_systems = [
+            subset_pras_system(pruned_base_pras_system_full, season_cols[s]) for
+            s in valid_seasons
+        ]
+        season_augmented_systems =
+            [augmented_pras_season_systems[s] for s in valid_seasons]
+        accreditations = [
+            PRAS.ELCC{ra_metric}(
+                Int(ceil(total_capacity)),
+                regional_load_shares_by_season[s],
             ) for s in valid_seasons
+        ]
+        cc_results = Distributed.pmap(
+            pras_assess_cc,
+            season_pruned_systems,
+            season_augmented_systems,
+            accreditations,
+            fill(total_capacity, length(valid_seasons)),
         )
-        cc_results = Distributed.pmap(valid_seasons) do s
-            season_pruned_system, season_augmented_system, accreditation, cap =
-                season_assess_args[s]
-            cc_final = pras_assess_cc(
-                season_pruned_system,
-                season_augmented_system,
-                accreditation,
-                cap,
-            )
-            s => cc_final
-        end
-        for (s, cc_final) in cc_results
+        for (s, cc_final) in zip(valid_seasons, cc_results)
             derating_factors[season_row_index[s], "existing_STOR_$(stor_duration)"] =
                 cc_final
         end
@@ -914,29 +909,26 @@ function calculate_derating_factors(
             )
 
             valid_seasons = [s for s in seasons if haskey(season_cols, s)]
-            season_assess_args = Dict(
-                s => (
-                    base_pras_season_systems[s],
-                    subset_pras_system(augmented_pras_system_full, season_cols[s]),
-                    methodology{ra_metric}(
-                        Int(ceil(max_cap)),
-                        regional_load_shares_by_season[s],
-                    ),
-                    max_cap,
+            season_base_systems =
+                [base_pras_season_systems[s] for s in valid_seasons]
+            season_augmented_systems = [
+                subset_pras_system(augmented_pras_system_full, season_cols[s]) for
+                s in valid_seasons
+            ]
+            accreditations = [
+                methodology{ra_metric}(
+                    Int(ceil(max_cap)),
+                    regional_load_shares_by_season[s],
                 ) for s in valid_seasons
+            ]
+            cc_results = Distributed.pmap(
+                pras_assess_cc,
+                season_base_systems,
+                season_augmented_systems,
+                accreditations,
+                fill(max_cap, length(valid_seasons)),
             )
-            cc_results = Distributed.pmap(valid_seasons) do s
-                season_base_system, season_augmented_system, accreditation, cap =
-                    season_assess_args[s]
-                cc_final = pras_assess_cc(
-                    season_base_system,
-                    season_augmented_system,
-                    accreditation,
-                    cap,
-                )
-                s => cc_final
-            end
-            for (s, cc_final) in cc_results
+            for (s, cc_final) in zip(valid_seasons, cc_results)
                 derating_factors[season_row_index[s], "new_STOR_$(stor_duration)"] =
                     cc_final
             end

--- a/src/resource_adequacy/ra_utils.jl
+++ b/src/resource_adequacy/ra_utils.jl
@@ -272,6 +272,139 @@ function create_capacity_mkt_system(initial_system::PSY.System,
     return capacity_market_system
 end
 
+"""
+    subset_pras_system(sys::PRAS.SystemModel{N,L,T,P,E}, cols::AbstractVector{Int}) where {N,L,T,P,E}
+
+Rebuilds a `PRAS.SystemModel` restricted to a subset of timestep columns, implementing
+the "divide" approach to seasonal PRAS accreditation.
+
+A built `PRAS.SystemModel{N,...}` bakes its timestep count `N` into its type, so it
+cannot be resliced in place. Instead, every time-indexed asset array (time is always
+the 2nd dimension) is copied and column-subset by `cols`, non-time-indexed fields
+(names/categories/region indices/interface-line indices) are passed through unchanged,
+and a new synthetic contiguous timestamp range is constructed:
+
+    N2 = length(cols)
+    ts0 = first(sys.timestamps); dt = step(sys.timestamps)
+    timestamps = ts0:dt:(ts0 + (N2 - 1) * dt)
+
+The returned system's timestamps are therefore NOT the true calendar timestamps of
+the selected hours; they are a synthetic contiguous stand-in of the same length,
+purely so that `PRAS.SystemModel`'s internal `StepRange{ZonedDateTime,T}` invariant
+(contiguous, uniform step) is satisfied. `PRAS.assess`/`SequentialMonteCarlo` only
+uses `1:N2` integer timestep indexing internally and does not read calendar semantics
+from `timestamps`, so this is safe for accreditation purposes.
+
+SoC / outage-seam caveat (divide-approach limitation, accepted as-is): PRAS's
+SequentialMonteCarlo simulation loops over integer timesteps `1:N2` with no
+awareness of the calendar gaps between the (possibly non-contiguous) hours selected
+by `cols`. This means:
+  - Storage/generator-storage state of charge is only initialized to empty at
+    timestep 1 of the subset, and then carries across every seam between the
+    stitched-together blocks of hours in `cols` (e.g. the boundary between one
+    simulation-year's last summer hour and the next simulation-year's first
+    summer hour).
+  - Generator/line/storage forced-outage Markov states persist across those same
+    seams in the same way.
+A multi-year seasonal subset therefore reads as one continuous stitched block
+("all summers back-to-back"), not as independent blocks that each reset at the
+start of the season. This is inherent to the divide approach and is accepted here,
+not corrected.
+"""
+function subset_pras_system(
+    sys::PRAS.SystemModel{N,L,T,P,E},
+    cols::AbstractVector{Int},
+) where {N,L,T,P,E}
+    N2 = length(cols)
+
+    ts0 = first(sys.timestamps)
+    dt = step(sys.timestamps)
+    timestamps = ts0:dt:(ts0 + (N2 - 1) * dt)
+
+    regions = PRAS.Regions{N2,P}(
+        sys.regions.names,
+        copy(sys.regions.load[:, cols]),
+    )
+
+    interfaces = PRAS.Interfaces{N2,P}(
+        sys.interfaces.regions_from,
+        sys.interfaces.regions_to,
+        copy(sys.interfaces.limit_forward[:, cols]),
+        copy(sys.interfaces.limit_backward[:, cols]),
+    )
+
+    generators = PRAS.Generators{N2,L,T,P}(
+        sys.generators.names,
+        sys.generators.categories,
+        copy(sys.generators.capacity[:, cols]),
+        copy(sys.generators.λ[:, cols]),
+        copy(sys.generators.μ[:, cols]),
+    )
+
+    storages = PRAS.Storages{N2,L,T,P,E}(
+        sys.storages.names,
+        sys.storages.categories,
+        copy(sys.storages.charge_capacity[:, cols]),
+        copy(sys.storages.discharge_capacity[:, cols]),
+        copy(sys.storages.energy_capacity[:, cols]),
+        copy(sys.storages.charge_efficiency[:, cols]),
+        copy(sys.storages.discharge_efficiency[:, cols]),
+        copy(sys.storages.carryover_efficiency[:, cols]),
+        copy(sys.storages.λ[:, cols]),
+        copy(sys.storages.μ[:, cols]),
+    )
+
+    generatorstorages = PRAS.GeneratorStorages{N2,L,T,P,E}(
+        sys.generatorstorages.names,
+        sys.generatorstorages.categories,
+        copy(sys.generatorstorages.charge_capacity[:, cols]),
+        copy(sys.generatorstorages.discharge_capacity[:, cols]),
+        copy(sys.generatorstorages.energy_capacity[:, cols]),
+        copy(sys.generatorstorages.charge_efficiency[:, cols]),
+        copy(sys.generatorstorages.discharge_efficiency[:, cols]),
+        copy(sys.generatorstorages.carryover_efficiency[:, cols]),
+        copy(sys.generatorstorages.inflow[:, cols]),
+        copy(sys.generatorstorages.gridwithdrawal_capacity[:, cols]),
+        copy(sys.generatorstorages.gridinjection_capacity[:, cols]),
+        copy(sys.generatorstorages.λ[:, cols]),
+        copy(sys.generatorstorages.μ[:, cols]),
+    )
+
+    demandresponses = PRAS.DemandResponses{N2,L,T,P,E}(
+        sys.demandresponses.names,
+        sys.demandresponses.categories,
+        copy(sys.demandresponses.borrow_capacity[:, cols]),
+        copy(sys.demandresponses.payback_capacity[:, cols]),
+        copy(sys.demandresponses.energy_capacity[:, cols]),
+        copy(sys.demandresponses.borrowed_energy_interest[:, cols]),
+        copy(sys.demandresponses.allowable_payback_period[:, cols]),
+        copy(sys.demandresponses.λ[:, cols]),
+        copy(sys.demandresponses.μ[:, cols]),
+        copy(sys.demandresponses.borrow_efficiency[:, cols]),
+        copy(sys.demandresponses.payback_efficiency[:, cols]),
+    )
+
+    lines = PRAS.Lines{N2,L,T,P}(
+        sys.lines.names,
+        sys.lines.categories,
+        copy(sys.lines.forward_capacity[:, cols]),
+        copy(sys.lines.backward_capacity[:, cols]),
+        copy(sys.lines.λ[:, cols]),
+        copy(sys.lines.μ[:, cols]),
+    )
+
+    return PRAS.SystemModel(
+        regions, interfaces,
+        generators, sys.region_gen_idxs,
+        storages, sys.region_stor_idxs,
+        generatorstorages, sys.region_genstor_idxs,
+        demandresponses, sys.region_dr_idxs,
+        lines, sys.interface_line_idxs,
+        timestamps,
+        copy(sys.attrs),
+    )
+end
+
 function check_ra_conditions(
     ra_targets::Dict{String, Float64},
     ra_metrics::Dict{String, Float64},

--- a/src/utils/general.jl
+++ b/src/utils/general.jl
@@ -352,6 +352,43 @@ function load_season_months(seasons_file::String)
 end
 
 """
+    season_hour_columns(season_months::Vector{Int64}, simulation_years::Int) -> Vector{Int}
+
+Returns the ascending vector of hour-columns (1-indexed, 1:(DEFAULT_HOURS_PER_YEAR *
+simulation_years)) whose calendar month falls in `season_months`. Ascending hour order
+is the true chronological (month-year) stitch order required by the divide approach:
+within each simulation year, hours are selected in calendar order, and simulation years
+are concatenated in order (e.g. for a summer season across 2 years, all of year 1's
+summer hours precede all of year 2's summer hours).
+
+Month bucketing uses a fixed non-leap hour-of-year mapping: each hour is reduced to its
+hour-of-year via `mod(h - 1, DEFAULT_HOURS_PER_YEAR)` and its month is taken within the
+non-leap reference year `SIM_START_DATE`. This deliberately aligns with the underlying
+load/availability/outage timeseries, which are assembled as fixed 8760-hour (no leap
+day) blocks per simulation year. It intentionally does NOT use leap-aware wall-clock
+arithmetic across the full horizon: doing so would drift by up to ~one day per month
+boundary in every simulation year that crosses a calendar leap year (e.g. horizons ≥ 3
+years from SIM_START_DATE=2018), mis-bucketing ~24 hours per boundary into the wrong
+season relative to the data. The PRAS assessment ignores calendar semantics of the
+timestamp axis, so diverging from the leap-aware timestamp labels here is harmless.
+"""
+function season_hour_columns(season_months::Vector{Int64}, simulation_years::Int)
+    total_hours = DEFAULT_HOURS_PER_YEAR * simulation_years
+    season_month_set = Set(season_months)
+    # Precompute the constant hour-of-year → month table once (non-leap reference year),
+    # matching the no-leap 8760-hour data blocks rather than the leap-aware timestamp axis.
+    hoy_month = [Dates.month(SIM_START_DATE + Dates.Hour(hoy)) for hoy in 0:(DEFAULT_HOURS_PER_YEAR - 1)]
+    cols = Int[]
+    for h in 1:total_hours
+        hoy = mod(h - 1, DEFAULT_HOURS_PER_YEAR)
+        if hoy_month[hoy + 1] in season_month_set
+            push!(cols, h)
+        end
+    end
+    return cols
+end
+
+"""
 Parses a month value from numeric, date/datetime, or string inputs.
 Accepts month numbers, date-like strings, and month names/abbreviations.
 """

--- a/test/test_seasonal_capacity_markets.jl
+++ b/test/test_seasonal_capacity_markets.jl
@@ -1172,3 +1172,102 @@ end
         end
     end
 end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Phase 2a PRAS — seasonal divide (season_hour_columns / subset_pras_system)
+# ─────────────────────────────────────────────────────────────────────────────
+#
+# calculate_derating_factors itself (the full PRAS.assess pipeline) needs a real
+# AgentSimulation + fully-built PRAS.SystemModel fixture and is out of scope for
+# this file (see the header note on calculate_derating_data/calculate_derating_factors
+# above). These tests instead cover the two new, cheap, pure units it is built
+# from: `season_hour_columns` (hour-column selection per season) and
+# `subset_pras_system` (the divide-approach column-subset SystemModel rebuild).
+
+import PRAS
+import TimeZones
+import Dates
+
+@testset "Phase 2a PRAS — seasonal divide" begin
+    @testset "season_hour_columns selects only the requested months, ascending, across years" begin
+        simulation_years = 2
+        months = [6, 7, 8]
+        cols = EMISAgentSimulation.season_hour_columns(months, simulation_years)
+
+        @test issorted(cols)
+        @test allunique(cols)
+
+        # 2018 and 2019 (the two years spanned by an 8760 hr/yr, non-leap simulation
+        # horizon starting 2018-01-01) are both non-leap, so this count applies to
+        # each simulation year.
+        expected_hours_per_year = sum(Dates.daysinmonth(2018, m) * 24 for m in months)
+        @test length(cols) == expected_hours_per_year * simulation_years
+
+        # Every selected hour really does fall in Jun/Jul/Aug.
+        sim_start = Dates.DateTime("2018-01-01T00:00:00")
+        @test all(Dates.month(sim_start + Dates.Hour(h - 1)) in months for h in cols)
+
+        # Spans both simulation years (a genuine month-year stitch, not just year 1).
+        @test maximum(cols) > 8760
+    end
+
+    @testset "season_hour_columns(1:12, 1) reproduces the full annual hour range" begin
+        cols = EMISAgentSimulation.season_hour_columns(collect(1:12), 1)
+        @test cols == collect(1:8760)
+    end
+
+    @testset "subset_pras_system rebuilds a SystemModel over a column subset" begin
+        N = 24
+        P = PRAS.MW
+        E = PRAS.MWh
+        Tp = Dates.Hour
+
+        capacity = reshape(Int.(50 .+ (1:N)), 1, N)
+        gen_lambda = reshape(fill(0.05, N), 1, N)
+        gen_mu = reshape(fill(0.95, N), 1, N)
+        load = reshape(Int.(10 .+ (1:N)), 1, N)
+
+        regions = PRAS.Regions{N, P}(["Z1"], load)
+        interfaces = PRAS.Interfaces{N, P}()
+        generators =
+            PRAS.Generators{N, 1, Tp, P}(["Gen1"], ["Thermal"], capacity, gen_lambda, gen_mu)
+        storages = PRAS.Storages{N, 1, Tp, P, E}()
+        generatorstorages = PRAS.GeneratorStorages{N, 1, Tp, P, E}()
+        demandresponses = PRAS.DemandResponses{N, 1, Tp, P, E}()
+        lines = PRAS.Lines{N, 1, Tp, P}()
+
+        ts0 = TimeZones.ZonedDateTime(2018, 1, 1, 0, 0, 0, TimeZones.tz"UTC")
+        timestamps = ts0:Dates.Hour(1):(ts0 + Dates.Hour(N - 1))
+
+        sys = PRAS.SystemModel(
+            regions, interfaces,
+            generators, [1:1],
+            storages, [1:0],
+            generatorstorages, [1:0],
+            demandresponses, [1:0],
+            lines, UnitRange{Int}[],
+            timestamps,
+        )
+
+        @testset "arbitrary column subset" begin
+            cols = [3, 4, 5, 10, 11]
+            sub = EMISAgentSimulation.subset_pras_system(sys, cols)
+
+            @test length(sub.timestamps) == length(cols)
+            @test step(sub.timestamps) == step(sys.timestamps)
+            @test sub.timestamps ==
+                  first(sys.timestamps):step(sys.timestamps):(first(sys.timestamps) + Dates.Hour(length(cols) - 1))
+            @test sub.generators.capacity == capacity[:, cols]
+            @test sub.regions.load == load[:, cols]
+            @test sub.generators.names == sys.generators.names
+        end
+
+        @testset "annual-equivalence: subsetting by all columns reproduces the original" begin
+            full = EMISAgentSimulation.subset_pras_system(sys, collect(1:N))
+            @test full.generators.capacity == sys.generators.capacity
+            @test full.regions.load == sys.regions.load
+            @test length(full.timestamps) == length(sys.timestamps)
+            @test collect(full.timestamps) == collect(sys.timestamps)
+        end
+    end
+end

--- a/test/test_seasonal_capacity_markets.jl
+++ b/test/test_seasonal_capacity_markets.jl
@@ -1189,6 +1189,25 @@ import TimeZones
 import Dates
 
 @testset "Phase 2a PRAS — seasonal divide" begin
+    @testset "annual output normalizes a prior seasonal template" begin
+        template = DataFrame(
+            season = ["summer", "winter"],
+            CT = [0.81, 0.91],
+            existing_Wind_Z1 = [0.41, 0.27],
+        )
+
+        output = EMISAgentSimulation.initialize_derating_output(
+            template,
+            ["annual"],
+            false,
+        )
+
+        @test nrow(output) == 1
+        @test !("season" in names(output))
+        @test output[1, "CT"] == 0.81
+        @test output[1, "existing_Wind_Z1"] == 0.41
+    end
+
     @testset "season_hour_columns selects only the requested months, ascending, across years" begin
         simulation_years = 2
         months = [6, 7, 8]


### PR DESCRIPTION
This PR adds the PRAS derating factor calculation logic for seasonal capacity markets. Currently PRAS does not support simulations using discontinuous time ranges. There is a PR on PRAS (https://github.com/NatLabRockies/PRAS/pull/110) but there is no fixed timeline of when that will be merged/released. This PR uses tries to bypass that by using a splitting and stitching approach:

- The hours corresponding to each season are determined for the full simulation horizon. For example, for a 15 year simulation all the summer months and winter months corresponding hours are retrieved.
- A substitute system is constructed by concatenation of the seasonal hours and replacing the discontinuous timestamp ranges with a dummy continuous timestamp range.
- After the completion of the seasonal simulations the final cc results are stitched back together using their row index
- Each seasonal run has been parallelized using the distributed worker similar to `calculate_ra_metrics`
- Unit tests added